### PR TITLE
Fixing capitalization of 'Package' for non-mac puppetmaster compatibi…

### DIFF
--- a/lib/puppet/provider/apple_package_installer/macos.rb
+++ b/lib/puppet/provider/apple_package_installer/macos.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:apple_package_installer).provide(:macos) do
   commands pkgutil: '/usr/sbin/pkgutil'
 
   require 'puppet/util/plist' if Puppet.features.cfpropertylist?
-  require 'puppet/util/Package'
+  require 'puppet/util/package'
   require 'digest'
 
   def check_for_install(receipt, version, installs, checksum, force_install, force_downgrade)


### PR DESCRIPTION
…lity

In our environment, with a Linux puppetmaster and Mac OS clients, the capitalization of Package in the macos provider breaks things because Linux is not a case-insensitive filesystem.