### PR TITLE
Support for remote file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This Puppet module provides a better method to install packages for macOS than t
 * If passed an array of files to verify, it will reinstall the package if any of the files are missing (optional).
 * If passed an array of SHA1 checksums, it will reinstall the package if any of the files specified have a different checksum (optional).
 * If passed a parameter of downgrade set to true and a newer version is installed, it will be downgraded to the specified version.  Otherwise, newer versions are left untouched.
+* Can download packages from a webserver rather than relying on Puppet's fileserver.
 
 ## Example
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,6 @@ define apple_package (
   Array $checksum = [],
   Boolean $force_install = false,
   Boolean $force_downgrade = false,
-  Boolean $remote_package = false,
   String $http_checksum = '',
   String $http_checksum_type = 'sha256',
   String $http_username = '',
@@ -21,6 +20,12 @@ define apple_package (
     file { "${facts['puppet_vardir']}/packages":
       ensure => directory,
     }
+  }
+
+  if 'puppet:///' in $source {
+    $remote_package = false
+  } else {
+    $remote_package = true
   }
 
   if $remote_package {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,12 @@ define apple_package (
   Array $installs = [],
   Array $checksum = [],
   Boolean $force_install = false,
-  Boolean $force_downgrade = false
+  Boolean $force_downgrade = false,
+  Boolean $remote_package = false,
+  String $http_checksum = '',
+  String $http_checksum_type = 'sha256',
+  String $http_username = '',
+  String $http_password = ''
 ) {
 
   $package_location = "${facts['puppet_vardir']}/packages/${title}.pkg"
@@ -18,13 +23,27 @@ define apple_package (
     }
   }
 
-  file { $package_location:
-    ensure  => file,
-    source  => $source,
-    mode    => '0644',
-    backup  => false,
-    require => File["${facts['puppet_vardir']}/packages"],
+  if $remote_package {
+    remote_file { $package_location:
+      ensure        => present,
+      source        => $source,
+      checksum      => $http_checksum,
+      checksum_type => $http_checksum_type,
+      username      => $http_username,
+      password      => $http_password
+    }
+
+  } else {
+    file { $package_location:
+        ensure  => file,
+        source  => $source,
+        mode    => '0644',
+        backup  => false,
+        require => File["${facts['puppet_vardir']}/packages"],
+      }
   }
+
+
 
   apple_package_installer {$title:
     ensure          => $ensure,


### PR DESCRIPTION
This will let us host packages on a web server as well as rely on Puppet's fileserver.