### PR TITLE
support unauthenticated http package sources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,15 +29,22 @@ define apple_package (
   }
 
   if $remote_package {
+    if $http_username != '' and $http_password != '' {
+      $http_attributes = {
+        'username' => $http_username,
+        'password' => $http_password,
+      }
+    } else {
+      $http_attributes = {}
+    }
+
     remote_file { $package_location:
       ensure        => present,
       source        => $source,
       checksum      => $http_checksum,
       checksum_type => $http_checksum_type,
-      username      => $http_username,
-      password      => $http_password
+      *             => $http_attributes,
     }
-
   } else {
     file { $package_location:
         ensure  => file,
@@ -47,8 +54,6 @@ define apple_package (
         require => File["${facts['puppet_vardir']}/packages"],
       }
   }
-
-
 
   apple_package_installer {$title:
     ensure          => $ensure,


### PR DESCRIPTION
## changes

- only make authenticated requests for `remote_file` resources when username and password are not empty

## testing

- verified that both authenticated and unauthenticated requests work as expected